### PR TITLE
Allow setting `.gitignore` filename

### DIFF
--- a/src/GitIgnoreChecker.php
+++ b/src/GitIgnoreChecker.php
@@ -24,15 +24,23 @@ final class GitIgnoreChecker
     protected $repository;
 
     /**
+     * Filename for the gitignore rules.
+     *
+     * @var string
+     */
+    protected $gitignore = '.gitignore';
+
+    /**
      * GitIgnoreChecker constructor.
      *
      * @param string $repositoryPath absolute path representing the Repository project root
      * @throws InvalidArgumentException
      * @throws LogicException
      */
-    public function __construct($repositoryPath)
+    public function __construct($repositoryPath, $gitignore = '.gitignore')
     {
         $this->repository = new Repository($repositoryPath);
+        $this->gitignore  = $gitignore;
     }
 
     /**
@@ -92,6 +100,6 @@ final class GitIgnoreChecker
      */
     private function searchGitIgnoreFileInRelativePath(RelativePath $relativePath) : File
     {
-        return File::buildFromRelativePathContainingGitIgnore($relativePath);
+        return File::buildFromRelativePathContainingGitIgnore($relativePath, $this->gitignore);
     }
 }

--- a/src/GitIgnoreChecker.php
+++ b/src/GitIgnoreChecker.php
@@ -24,23 +24,27 @@ final class GitIgnoreChecker
     protected $repository;
 
     /**
-     * Filename for the gitignore rules.
+     * Filename to look for containing the gitignore rules.
+     *
+     * This is `.gitignore` for Git repositories, but other libraries may use the same syntax for similar purposes.
+     * @see https://github.com/wp-cli/dist-archive-command/
      *
      * @var string
      */
-    protected $gitignore = '.gitignore';
+    protected $gitignoreFilename = '.gitignore';
 
     /**
      * GitIgnoreChecker constructor.
      *
      * @param string $repositoryPath absolute path representing the Repository project root
+     * @param string $gitignoreFilename The filename for the text file containing the rules.
      * @throws InvalidArgumentException
      * @throws LogicException
      */
-    public function __construct($repositoryPath, $gitignore = '.gitignore')
+    public function __construct($repositoryPath, string $gitignoreFilename = '.gitignore')
     {
         $this->repository = new Repository($repositoryPath);
-        $this->gitignore  = $gitignore;
+        $this->gitignoreFilename  = $gitignoreFilename;
     }
 
     /**
@@ -100,6 +104,6 @@ final class GitIgnoreChecker
      */
     private function searchGitIgnoreFileInRelativePath(RelativePath $relativePath) : File
     {
-        return File::buildFromRelativePathContainingGitIgnore($relativePath, $this->gitignore);
+        return File::buildFromRelativePathContainingGitIgnore($relativePath, $this->gitignoreFilename);
     }
 }

--- a/src/Model/GitIgnore/File.php
+++ b/src/Model/GitIgnore/File.php
@@ -49,12 +49,12 @@ class File
      * @throws InvalidArgumentException
      * @throws LogicException
      */
-    public static function buildFromRelativePathContainingGitIgnore(RelativePath $relativePathContainingGitIgnore) : File
+    public static function buildFromRelativePathContainingGitIgnore(RelativePath $relativePathContainingGitIgnore, $gitignoreFilename = '.gitignore') : File
     {
         $obj = new File();
 
-        $obj->setRelativePath($relativePathContainingGitIgnore);
-        $gitIgnorePath = $obj->getAbsolutePathForGitIgnore();
+        $obj->setRelativePath($relativePathContainingGitIgnore, $gitignoreFilename);
+        $gitIgnorePath = $obj->getAbsolutePathForGitIgnore($gitignoreFilename);
 
         $obj->parseContentByReadingFile($gitIgnorePath);
 
@@ -89,7 +89,7 @@ class File
      * @throws InvalidArgumentException
      * @throws FileNotFoundException
      */
-    private function setRelativePath(RelativePath $relativePathContainingGitIgnore) : File
+    private function setRelativePath(RelativePath $relativePathContainingGitIgnore, $gitignoreFilename) : File
     {
         if (!$relativePathContainingGitIgnore->isFolder()) {
             throw new \InvalidArgumentException();
@@ -98,7 +98,7 @@ class File
         /*
          * check that $path represents the path containing the .gitignore file, not the path containing the ".gitignore" string
          */
-        if (preg_match("#\.gitignore$#", $relativePathContainingGitIgnore->getPath())) {
+        if (preg_match('#'.preg_quote($gitignoreFilename,'\\').'$#', $relativePathContainingGitIgnore->getPath())) {
             throw new InvalidArgumentException(
                 sprintf("The path must not end with .gitignore: \"%s\" given.", $relativePathContainingGitIgnore->getPath())
             );
@@ -107,7 +107,7 @@ class File
         /*
          * check that a file ".gitignore" is actually found in $relativePathContainingGitIgnore
          */
-        if (!$relativePathContainingGitIgnore->containsPath('/.gitignore')) {
+        if (!$relativePathContainingGitIgnore->containsPath("/$gitignoreFilename")) {
             throw new FileNotFoundException(
                 sprintf("The path \"%s\" does not contain a .gitignore file.", $relativePathContainingGitIgnore->getPath())
             );
@@ -124,9 +124,9 @@ class File
      * @param RelativePath $relativePathContainingGitIgnore
      * @return string
      */
-    private function getAbsolutePathForGitIgnore() : string
+    private function getAbsolutePathForGitIgnore($gitignore) : string
     {
-        return sprintf("%s/.gitignore", $this->relativePath->getAbsolutePath());
+        return sprintf("%s/%s", $this->relativePath->getAbsolutePath(),$gitignore);
     }
 
     /**

--- a/src/Model/GitIgnore/File.php
+++ b/src/Model/GitIgnore/File.php
@@ -85,11 +85,12 @@ class File
      * Set relative path containing the .gitignore file
      *
      * @param RelativePath $relativePathContainingGitIgnore
+     * @param string $gitignoreFilename The name of the text file containing the gitignore rules.
      * @return File
      * @throws InvalidArgumentException
      * @throws FileNotFoundException
      */
-    private function setRelativePath(RelativePath $relativePathContainingGitIgnore, $gitignoreFilename) : File
+    private function setRelativePath(RelativePath $relativePathContainingGitIgnore, string $gitignoreFilename = '.gitignore') : File
     {
         if (!$relativePathContainingGitIgnore->isFolder()) {
             throw new \InvalidArgumentException();
@@ -100,7 +101,7 @@ class File
          */
         if (preg_match('#'.preg_quote($gitignoreFilename,'\\').'$#', $relativePathContainingGitIgnore->getPath())) {
             throw new InvalidArgumentException(
-                sprintf("The path must not end with .gitignore: \"%s\" given.", $relativePathContainingGitIgnore->getPath())
+                sprintf("The path must not end with %s: \"%s\" given.", $gitignoreFilename, $relativePathContainingGitIgnore->getPath())
             );
         }
 
@@ -109,7 +110,7 @@ class File
          */
         if (!$relativePathContainingGitIgnore->containsPath("/$gitignoreFilename")) {
             throw new FileNotFoundException(
-                sprintf("The path \"%s\" does not contain a .gitignore file.", $relativePathContainingGitIgnore->getPath())
+                sprintf("The path \"%s\" does not contain a %s file.", $relativePathContainingGitIgnore->getPath(), $gitignoreFilename)
             );
         }
 
@@ -121,12 +122,12 @@ class File
     /**
      * Return the absolute path for the .gitignore file
      *
-     * @param RelativePath $relativePathContainingGitIgnore
+     * @param string $gitignoreFilename The filename containing the rules.
      * @return string
      */
-    private function getAbsolutePathForGitIgnore($gitignore) : string
+    private function getAbsolutePathForGitIgnore(string $gitignoreFilename = '.gitignore') : string
     {
-        return sprintf("%s/%s", $this->relativePath->getAbsolutePath(),$gitignore);
+        return sprintf("%s/%s", $this->relativePath->getAbsolutePath(), $gitignoreFilename);
     }
 
     /**


### PR DESCRIPTION
Hi and thanks for the great project.

The WordPress CLI tool, [dist-archive-command](https://github.com/wp-cli/dist-archive-command), used to create zip files for plugin distribution, has a `.distignore` file for exclusion rules, whose syntax [we would like to match](https://github.com/wp-cli/dist-archive-command/issues/44) `.gitignore`. Your library is ideal for implementing this, but until now has the filename `.gitignore` hardcoded. 

This PR allows passing any filename to be used from which to read the rules.

There are no breaking changes in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inmarelibero/gitignore-checker/11)
<!-- Reviewable:end -->
