### PR TITLE
Skip comment lines and empty lines

### DIFF
--- a/src/Model/GitIgnore/File.php
+++ b/src/Model/GitIgnore/File.php
@@ -185,6 +185,9 @@ class File
         $lines = array_values($lines);
 
         foreach ($lines as $k => $line) {
+            if (empty($line) || strpos($line, '#') === 0) {
+                continue;
+            }
             $this->rules[] = new Rule($this, $line, $k);
         }
 


### PR DESCRIPTION
There was already logic inside [Rule.php](https://github.com/inmarelibero/gitignore-checker/blob/f2aeb883b4018c10adafb2820d1f7d1e8b067da2/src/Model/GitIgnore/Rule.php#L60-L71) related to this, but no logic earlier in the process to just skip those irrelevant lines. 

This PR is a simple check which prevents creating new Rules for empty lines and comment lines.

There are no breaking changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inmarelibero/gitignore-checker/12)
<!-- Reviewable:end -->
