### PR TITLE
Fix: dynamic property deprecation warning in PHP 8.2 +

### DIFF
--- a/src/Model/GitIgnore/File.php
+++ b/src/Model/GitIgnore/File.php
@@ -189,7 +189,7 @@ class File
             if (empty($line) || strpos($line, '#') === 0) {
                 continue;
             }
-            $this->rules[] = new Rule($this, $line, $k);
+            $this->rules[] = new Rule($line, $k);
         }
 
         return $this->getRules();

--- a/src/Model/GitIgnore/Rule.php
+++ b/src/Model/GitIgnore/Rule.php
@@ -18,8 +18,6 @@ use Inmarelibero\GitIgnoreChecker\Utils\PathUtils;
  */
 class Rule
 {
-    protected File $gitIgnoreFile;
-
     /**
      * @var string represents a line of a .gitignre file
      */
@@ -33,14 +31,12 @@ class Rule
     /**
      * Rule constructor.
      *
-     * @param File $file
      * @param string $rule
      * @param int $index the row number in the original .gitignore file
      * @throws InvalidArgumentException
      */
-    public function __construct(File $file, string $rule, int $index)
+    public function __construct(string $rule, int $index)
     {
-        $this->gitIgnoreFile = $file;
         $this->setRule($rule);
         $this->setIndex($index);
     }

--- a/src/Model/GitIgnore/Rule.php
+++ b/src/Model/GitIgnore/Rule.php
@@ -18,10 +18,7 @@ use Inmarelibero\GitIgnoreChecker\Utils\PathUtils;
  */
 class Rule
 {
-    /**
-     * @var File
-     */
-    protected $file;
+    protected File $gitIgnoreFile;
 
     /**
      * @var string represents a line of a .gitignre file

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -83,7 +83,6 @@ class AbstractTestCase extends TestCase
         }
 
         $ruleObj = new Rule(
-            File::buildFromRelativePathContainingGitIgnore(new RelativePath($this->getTestRepository(), '/')),
             $rule,
             0
         );

--- a/tests/Model/GitIgnore/RuleTest.php
+++ b/tests/Model/GitIgnore/RuleTest.php
@@ -30,7 +30,6 @@ class RuleTest extends AbstractTestCase
                  ] as $rule) {
             try {
                 new Rule(
-                    File::buildFromRelativePathContainingGitIgnore(new RelativePath($this->getTestRepository(), '/')),
                     $rule,
                     0
                 );


### PR DESCRIPTION
> Creation of dynamic property Inmarelibero\GitIgnoreChecker\Model\GitIgnore\Rule::$gitIgnoreFile is deprecated

Looks like the property was named `$file` in the class and referenced as `$gitIgnoreFile` in the constructor.

TBH, I don't the property is being used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inmarelibero/gitignore-checker/14)
<!-- Reviewable:end -->
